### PR TITLE
fix date inputArea (previous day bug)

### DIFF
--- a/src/components/InputArea/index.tsx
+++ b/src/components/InputArea/index.tsx
@@ -3,6 +3,7 @@ import * as C from './styles';
 import { Item } from '../../types/Item';
 
 import { categories } from '../../data/categories';
+import { newDateAdjusted } from '../../helpers/dateFilter';
 
 type Props = {
   onAdd: (item: Item) => void;
@@ -36,7 +37,7 @@ export const InputArea = ({ onAdd }: Props) => {
       alert(errors.join("\n"));
     } else {
       onAdd({
-        date: new Date(dateField),
+        date: newDateAdjusted(dateField),
         category: categoryField,
         title: titleField,
         value: valueField

--- a/src/helpers/dateFilter.ts
+++ b/src/helpers/dateFilter.ts
@@ -35,3 +35,8 @@ export const formatCurrentMonth = (currentMonth: string): string => {
     let months = ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro'];
     return `${months[parseInt(month) - 1]} de ${year}`;
 }
+
+export const newDateAdjusted = (dateField: string) => {
+    let [year, month, day] = dateField.split('-')
+    return new Date(parseInt(year), parseInt(month) - 1, parseInt(day))
+  }


### PR DESCRIPTION
## English version
When adding a new record, it is being saved with the date of the day before the one chosen.

![image](https://user-images.githubusercontent.com/33127367/156701449-5a6a3342-2b60-4b06-a34e-05123dc93c2e.png)
_Defined 04/03/2022 (dd-mm-yyyy)_

![image](https://user-images.githubusercontent.com/33127367/156701565-b2713e66-912e-43a6-998c-91871f38cef3.png)
_Added as 03/03/2022_

This change is intended to fix this bug.


## Versão em Português... ~~Versão brasileira. Herbert Richers~~
Ao adicionar um novo registro, está sendo salvo com a data do dia anterior à escolhida. Essa alteração tem como objetivo corrigir esse bug.